### PR TITLE
MF-89  react-root-decorator tests are broken

### DIFF
--- a/src/openmrs-react-root-decorator.js
+++ b/src/openmrs-react-root-decorator.js
@@ -35,6 +35,7 @@ export default function decorateOptions(opts) {
         }
       }
       componentDidCatch(err, info) {
+        console.log("Component did catch!");
         if (info && info.componentStack) {
           err.extra = Object.assign(err.extra || {}, {
             componentStack: info.componentStack

--- a/src/openmrs-react-root-decorator.test.js
+++ b/src/openmrs-react-root-decorator.test.js
@@ -12,9 +12,14 @@ describe("openmrs-react-root-decorator", () => {
 
   it("catches any errors in the component tree and renders a ui explaining something bad happened", () => {
     const DecoratedComp = openmrsRootDecorator(opts)(CompThatThrows);
-    const container = render(<DecoratedComp />);
-    console.log("rendered!");
-    expect(container.firstChild).toBeNull();
+    console.log("wrapped!");
+    try {
+      const container = render(<DecoratedComp />);
+      console.log("rendered!");
+    } catch (err) {
+      console.log("Caught in test code");
+      // expected
+    }
     // TODO assert that a real UX is showing for catastrophic errors
   });
 });

--- a/src/openmrs-react-root-decorator.test.js
+++ b/src/openmrs-react-root-decorator.test.js
@@ -12,12 +12,9 @@ describe("openmrs-react-root-decorator", () => {
 
   it("catches any errors in the component tree and renders a ui explaining something bad happened", () => {
     const DecoratedComp = openmrsRootDecorator(opts)(CompThatThrows);
-    try {
-      render(<DecoratedComp />);
-    } catch (err) {
-      // expected
-    }
-
+    const container = render(<DecoratedComp />);
+    console.log("rendered!");
+    expect(container.firstChild).toBeNull();
     // TODO assert that a real UX is showing for catastrophic errors
   });
 });
@@ -27,5 +24,7 @@ function CompThatWorks() {
 }
 
 function CompThatThrows() {
+  console.log("Throwing!");
+  console.trace();
   throw Error("ahahaa");
 }


### PR DESCRIPTION
This is a WIP, just messing around to try and diagnose the problem. I'm very confused by this problem. It seems like `render` is behaving asynchronously but returning synchronously (i.e., not a promise). Not sure how one is supposed to catch an error thrown in a situation like that. Also it would seem that the error is escaping the decorator.