### PR TITLE
Better error messaging when i18n.loadNamespaces rejects

### DIFF
--- a/src/openmrs-react-root-decorator.js
+++ b/src/openmrs-react-root-decorator.js
@@ -102,9 +102,21 @@ function I18nextLoadNamespace(props) {
   }
 
   if (!i18n.hasLoadedNamespace(props.ns)) {
-    throw i18n.loadNamespaces([props.ns]).catch(err => {
-      loadNamespaceErrRef.current = err;
-    });
+    const timeoutId = setTimeout(() => {
+      console.warn(
+        `openmrs-react-root-decorator: the React suspense promise for i18next.loadNamespaces(['${props.ns}']) did not resolve nor reject after three seconds. This could mean you have multiple versions of i18next and haven't made i18next a webpack external in all projects.`
+      );
+    }, 3000);
+
+    throw i18n
+      .loadNamespaces([props.ns])
+      .then(() => {
+        clearTimeout(timeoutId);
+      })
+      .catch(err => {
+        clearTimeout(timeoutId);
+        loadNamespaceErrRef.current = err;
+      });
   }
 
   return props.children;

--- a/src/openmrs-react-root-decorator.js
+++ b/src/openmrs-react-root-decorator.js
@@ -95,8 +95,16 @@ function I18nextLoadNamespace(props) {
     return () => i18n.off("languageChanged", props.forceUpdate);
   }, [props.forceUpdate]);
 
+  const loadNamespaceErrRef = React.useRef(null);
+
+  if (loadNamespaceErrRef.current) {
+    throw loadNamespaceErrRef.current;
+  }
+
   if (!i18n.hasLoadedNamespace(props.ns)) {
-    throw i18n.loadNamespaces([props.ns]);
+    throw i18n.loadNamespaces([props.ns]).catch(err => {
+      loadNamespaceErrRef.current = err;
+    });
   }
 
   return props.children;


### PR DESCRIPTION
See related https://github.com/facebook/react/issues/17526 and https://github.com/facebook/react/issues/17621 which explain why this is necessary